### PR TITLE
Output rest api ID from API gateway module

### DIFF
--- a/modules/apigw/outputs.tf
+++ b/modules/apigw/outputs.tf
@@ -5,3 +5,7 @@ output "http_method" {
 output "url" {
   value = aws_api_gateway_deployment.deployment.invoke_url
 }
+
+output "rest_api_id" {
+  value = aws_api_gateway_rest_api.api.id
+}


### PR DESCRIPTION
Just a small change from me again. We needed this output so that we could do some base path mapping configuration on the API Gateway